### PR TITLE
Add SoftBreak() function

### DIFF
--- a/JATS.lua
+++ b/JATS.lua
@@ -563,6 +563,10 @@ function DoubleQuoted(s)
   return '"' .. s .. '"'
 end
 
+function SoftBreak()
+  return "\n"
+end
+
 -- format in-text citation
 function Cite(s)
   local ids = {}


### PR DESCRIPTION
Pandoc would throw an error `Function SoftBreak() is not defined` on a string like this:

```
individual
  4 for each comparison.
```

This PR fixes that.